### PR TITLE
構文エラーを修正

### DIFF
--- a/UA.py
+++ b/UA.py
@@ -1,5 +1,6 @@
 #最近流行ってるUA(User Agent)取得です。python初心者なので、お手柔らかにお願いします()
-pip install requests
+import os
+os.system("pip install requests")
 import requests
 import json
 


### PR DESCRIPTION
```python
pip install requests
```
ってそのまま書いちゃうと Python に
「pip? そんな構文しらねーよ! エラーだよ!」
って怒られちゃう() ので、
```python
import os
os.system("pip install requests")
```
ってやるとコマンドプロンプトで実行しているのと同じ感じになって `requests` がインストールできます()
上から目線で大変申し訳ありません((